### PR TITLE
Service sanity check

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -38,7 +38,7 @@ var createServiceCmd = &cobra.Command{
 		}
 
 		configfileName := "haiku.yaml"
-		yamlData, err := createYamlConfig(envName, servName, serType, isPrivate == "yes")
+		yamlData, err := createYamlConfig(envName, servName, serType, isPrivate == "yes" || isPrivate == "y")
 		if err != nil {
 			return errors.New("unable to write data into the file")
 		}


### PR DESCRIPTION
1. added a sanity check for the service definition. User can enter in "no" and the haiku.yaml file will be deleted.
2. added a cli prompt for private service